### PR TITLE
Dont run xgboost examples

### DIFF
--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -167,7 +167,7 @@ rmse(actual = xtest$SalePrice, predicted = pred)
 ```
 
 **Xgboost**
-```{r}
+```{r, eval=FALSE}
 xgb <- XGBTrainer$new(objective = "reg:linear"
                       , n_estimators = 500
                       , eval_metric = "rmse"
@@ -180,7 +180,7 @@ rmse(actual = xtest$SalePrice, predicted = pred)
 ```
 
 **Grid Search**
-```{r}
+```{r, eval=FALSE}
 xgb <- XGBTrainer$new(objective = "reg:linear")
 
 gst <- GridSearchCV$new(trainer = xgb,
@@ -311,7 +311,7 @@ auc(actual = xtest$Survived, predicted = pred)
 ```
 
 **Xgboost**
-```{r}
+```{r, eval=FALSE}
 xgb <- XGBTrainer$new(objective = "binary:logistic"
                       , n_estimators = 500
                       , eval_metric = "auc"
@@ -325,7 +325,7 @@ auc(actual = xtest$Survived, predicted = pred)
 ```
 
 **Grid Search**
-```{r}
+```{r, eval=FALSE}
 xgb <- XGBTrainer$new(objective="binary:logistic")
 gst <-GridSearchCV$new(trainer = xgb,
                              parameters = list(n_estimators = c(10,50),


### PR DESCRIPTION
Fixes the following error in building on mac:

```
Error(s) in re-building vignettes:
--- re-building ‘Guide-to-CountVectorizer.Rmd’ using rmarkdown
--- finished re-building ‘Guide-to-CountVectorizer.Rmd’

--- re-building ‘Guide-to-TfidfVectorizer.Rmd’ using rmarkdown
--- finished re-building ‘Guide-to-TfidfVectorizer.Rmd’

--- re-building ‘introduction.Rmd’ using rmarkdown
Quitting from lines 171-180 (introduction.Rmd) 
Error: processing vignette 'introduction.Rmd' failed with diagnostics:
Inconsistent 'best_score' values between the closure state: 30943.7416707566 and the xgb.attr: 30943.7416707566
--- failed re-building ‘introduction.Rmd’

SUMMARY: processing the following file failed:
  ‘introduction.Rmd’

Error: Vignette re-building failed.
Execution halted

* checking PDF version of manual ... OK
* checking for detritus in the temp directory ... OK
* DONE

Status: 1 ERROR
See
  ‘/Users/ripley/R/packages/tests-devel/superml.Rcheck/00check.log’
for details.
```